### PR TITLE
update navigation.yml

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -11,9 +11,6 @@ links:
     url: /
   - title: About Us
     collection: about-us
-    sublinks:
-      - title: Careers
-        url: /careers
   - title: Individuals
     collection: individuals
   - title: Businesses


### PR DESCRIPTION
remove unnecessary careers sublink in navigation as careers is already added in the about-us collection