### PR TITLE
Addition of new announcement to update licensees regarding the Annual Declaration of Past Activities (ADPA) Exercise for Year 2020. 

### DIFF
--- a/_businesses/11-chemical-weapons-convention/011b1-announcement.md
+++ b/_businesses/11-chemical-weapons-convention/011b1-announcement.md
@@ -5,8 +5,17 @@ third_nav_title: Chemical Weapons Convention (CWC)
 ---
 
 # Announcement 
+
+**1 Dec 2020 **
+
+**Annual Declaration of Past Activities (ADPA) Exercise for Year 2020**
+
+The Annual Declaration of Past Activities (ADPA) Exercise for Year 2020 will commence from 1 Dec 2020 to 31 Jan 2021. Companies which have engaged in controlled activities involving Schedule 1, 2, 3 and Unscheduled Discrete Organic Chemicals are required to submit their ADPA by 31 Jan 2021. Please fill out the Declaration Cover for Reporting Template and the relevant declaration templates which can be accessed from the [Chemical Weapons Convention Forms section on the Customs Forms and Service Links page.](/eservices/customs-forms-and-service-links)
+
+
 **30 Oct 2020**
 
 **Chemical Weapons Convention Licence Renewal Exercise for Year 2021**
 
 The Chemical Weapons Convention (CWC) Licence Renewal exercise for Year 2021 will commence from 30 Oct 2020 to 31 Dec 2020. Companies engaging in the controlled activities may submit the licence renewal applications by 31 Dec 2020. Please fill out the licence application forms which can be accessed from the [Chemical Weapons Convention Forms section on the Customs Forms and Service Links page.](/eservices/customs-forms-and-service-links)
+

--- a/_businesses/11-chemical-weapons-convention/011b1-announcement.md
+++ b/_businesses/11-chemical-weapons-convention/011b1-announcement.md
@@ -6,11 +6,13 @@ third_nav_title: Chemical Weapons Convention (CWC)
 
 # Announcement 
 
-**1 Dec 2020 **
+**1 Dec 2020**
 
 **Annual Declaration of Past Activities (ADPA) Exercise for Year 2020**
 
 The Annual Declaration of Past Activities (ADPA) Exercise for Year 2020 will commence from 1 Dec 2020 to 31 Jan 2021. Companies which have engaged in controlled activities involving Schedule 1, 2, 3 and Unscheduled Discrete Organic Chemicals are required to submit their ADPA by 31 Jan 2021. Please fill out the Declaration Cover for Reporting Template and the relevant declaration templates which can be accessed from the [Chemical Weapons Convention Forms section on the Customs Forms and Service Links page.](/eservices/customs-forms-and-service-links)
+
+
 
 
 **30 Oct 2020**


### PR DESCRIPTION
1 Dec 2020 

Annual Declaration of Past Activities Exercise for Year 2020

The Annual Declaration of Past Activities (ADPA) Exercise for Year 2020 will commence from 1 Dec 2020 to 31 Jan 2021. Companies which have engaged in controlled activities involving Schedule 1, 2, 3 and Unscheduled Discrete Organic Chemicals are required to submit their ADPA by 31 Jan 2021. Please fill out the Declaration Cover for Reporting Template and the relevant declaration templates which can be accessed from the Chemical Weapons Convention Forms section on the Customs Forms and Service Links page.
